### PR TITLE
T/19 Post-fixer: create paragraph in empty root.

### DIFF
--- a/src/paragraph.js
+++ b/src/paragraph.js
@@ -243,7 +243,9 @@ function findEmptyRoots( doc, batch ) {
 		const root = doc.getRoot( rootName );
 
 		if ( root.isEmpty ) {
-			rootsToFix.set( root, batch );
+			if ( !rootsToFix.has( root ) ) {
+				rootsToFix.set( root, batch );
+			}
 		} else {
 			rootsToFix.delete( root );
 		}

--- a/src/paragraph.js
+++ b/src/paragraph.js
@@ -20,8 +20,6 @@ import modelWriter from '@ckeditor/ckeditor5-engine/src/model/writer';
 import buildModelConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildmodelconverter';
 import buildViewConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildviewconverter';
 
-import isArray from '@ckeditor/ckeditor5-utils/src/lib/lodash/isArray';
-
 /**
  * The paragraph feature for the editor.
  * Introduces the `<paragraph>` element in the model which renders as a `<p>` element in the DOM and data.
@@ -210,13 +208,7 @@ function mergeSubsequentParagraphs( evt, data ) {
 		return;
 	}
 
-	let node;
-
-	if ( isArray( data.output ) ) {
-		node = data.output[ 0 ];
-	} else {
-		node = data.output.getChild( 0 );
-	}
+	let node = data.output.getChild( 0 );
 
 	while ( node && node.nextSibling ) {
 		const nextSibling = node.nextSibling;

--- a/src/paragraph.js
+++ b/src/paragraph.js
@@ -75,6 +75,8 @@ export default class Paragraph extends Plugin {
 		editor.commands.set( 'paragraph', new ParagraphCommand( editor ) );
 
 		// Post-fixer that takes care of adding empty paragraph elements to empty roots.
+		// Besides fixing content on #changesDone we also need to handle #dataReady because
+		// if initial data is empty or setData() wasn't even called there will be no #change fired.
 		doc.on( 'change', ( evt, type, changes, batch ) => findEmptyRoots( doc, batch ) );
 		doc.on( 'changesDone', autoparagraphEmptyRoots, { priority: 'lowest' } );
 		editor.on( 'dataReady', () => {

--- a/tests/paragraph-intergration.js
+++ b/tests/paragraph-intergration.js
@@ -157,7 +157,6 @@ describe( 'Paragraph feature – integration', () => {
 					const doc = editor.document;
 					const root = doc.getRoot();
 
-					// Selection is in <p>, hence &nbsp;
 					expect( editor.getData() ).to.equal( '<p>&nbsp;</p>' );
 					expect( editor.commands.get( 'undo' ).isEnabled ).to.be.false;
 
@@ -180,6 +179,40 @@ describe( 'Paragraph feature – integration', () => {
 					editor.execute( 'undo' );
 
 					expect( editor.getData() ).to.equal( '<p>Foobar.</p>' );
+				} );
+		} );
+
+		it( 'fixing empty roots should be transparent to undo - multiple roots', () => {
+			return VirtualTestEditor.create( {
+				plugins: [ Paragraph, UndoEngine ]
+			} )
+				.then( newEditor => {
+					const editor = newEditor;
+					const doc = editor.document;
+					const root = doc.getRoot();
+					const otherRoot = doc.createRoot( '$root', 'otherRoot' );
+					editor.editing.createRoot( 'div', 'otherRoot' );
+
+					editor.data.set( '<p>Foobar.</p>', 'main' );
+					editor.data.set( '<p>Foobar.</p>', 'otherRoot' );
+
+					doc.enqueueChanges( () => {
+						doc.batch().remove( root.getChild( 0 ) );
+						doc.batch().remove( otherRoot.getChild( 0 ) );
+					} );
+
+					expect( editor.data.get( 'main' ) ).to.equal( '<p>&nbsp;</p>' );
+					expect( editor.data.get( 'otherRoot' ) ).to.equal( '<p>&nbsp;</p>' );
+
+					editor.execute( 'undo' );
+
+					expect( editor.data.get( 'main' ) ).to.equal( '<p>&nbsp;</p>' );
+					expect( editor.data.get( 'otherRoot' ) ).to.equal( '<p>Foobar.</p>' );
+
+					editor.execute( 'undo' );
+
+					expect( editor.data.get( 'main' ) ).to.equal( '<p>Foobar.</p>' );
+					expect( editor.data.get( 'otherRoot' ) ).to.equal( '<p>Foobar.</p>' );
 				} );
 		} );
 	} );

--- a/tests/paragraph-intergration.js
+++ b/tests/paragraph-intergration.js
@@ -150,8 +150,8 @@ describe( 'Paragraph feature – integration', () => {
 	describe( 'with undo', () => {
 		it( 'fixing empty roots should be transparent to undo', () => {
 			return VirtualTestEditor.create( {
-				plugins: [ Paragraph, UndoEngine ]
-			} )
+					plugins: [ Paragraph, UndoEngine ]
+				} )
 				.then( newEditor => {
 					const editor = newEditor;
 					const doc = editor.document;
@@ -184,8 +184,8 @@ describe( 'Paragraph feature – integration', () => {
 
 		it( 'fixing empty roots should be transparent to undo - multiple roots', () => {
 			return VirtualTestEditor.create( {
-				plugins: [ Paragraph, UndoEngine ]
-			} )
+					plugins: [ Paragraph, UndoEngine ]
+				} )
 				.then( newEditor => {
 					const editor = newEditor;
 					const doc = editor.document;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Empty roots that allow paragraph will now have a `paragraph` model element automatically added on `model.Document#event:changesDone` if they are empty. This "fix" will be added to the batch that caused the root to be empty. Closes ckeditor/ckeditor5#3301.